### PR TITLE
FEAT: apigateway IAM - add pagination

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # MyDevStack
 
-<img src="pkg/ui/public/logo.svg" alt="MyDevStack Logo" width="128" align="center" />
+<img src="./logo.svg" alt="MyDevStack Logo" width="128" align="center" />
 
 A modern, developer-friendly web interface for managing AWS services running locally via AWS emulators like LocalStack, FloCi, or MiniStack.
 

--- a/pkg/test/e2e/services/apigateway.spec.ts
+++ b/pkg/test/e2e/services/apigateway.spec.ts
@@ -1,5 +1,14 @@
 import { test, expect } from '../fixtures.js'
 
+async function showAllItems(page: any) {
+  const showLabel = page.getByText('Show:')
+  if (await showLabel.isVisible({ timeout: 2000 }).catch(() => false)) {
+    const perPageSelect = showLabel.locator('..').locator('select')
+    await perPageSelect.selectOption('50')
+    await page.waitForTimeout(300)
+  }
+}
+
 // Helper function to create a REST API
 async function createRestApi(page: any, name: string, description?: string) {
   await page.goto('/#/services/api-gateway')
@@ -36,6 +45,7 @@ async function createRestApi(page: any, name: string, description?: string) {
     // Try one more time with longer timeout
     await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 15000 })
   }
+  await showAllItems(page)
 }
 
 // Helper function to create an HTTP API
@@ -69,17 +79,18 @@ async function createHttpApi(page: any, name: string, description?: string) {
     }
     await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 15000 })
   }
+  await showAllItems(page)
 }
 
 test.describe('API Gateway', () => {
   test('navigate to service', async ({ page }) => {
-    await page.goto('http://localhost:3000/#/services/api-gateway')
+    await page.goto('/#/services/api-gateway')
     await page.waitForLoadState('networkidle')
     await expect(page.locator('h1').first()).toContainText('API Gateway', { timeout: 10000 })
   })
 
   test('navigate to REST APIs tab', async ({ page }) => {
-    await page.goto('http://localhost:3000/#/services/api-gateway')
+    await page.goto('/#/services/api-gateway')
     await page.waitForLoadState('networkidle')
 
 // Click REST APIs tab
@@ -90,7 +101,7 @@ test.describe('API Gateway', () => {
   })
 
   test('navigate to HTTP APIs tab', async ({ page }) => {
-    await page.goto('http://localhost:3000/#/services/api-gateway')
+    await page.goto('/#/services/api-gateway')
     await page.waitForLoadState('networkidle')
 
 // Click HTTP APIs tab
@@ -146,7 +157,7 @@ test.describe('API Gateway', () => {
     await page.waitForTimeout(3000)
 
     // Verify API appears in list - wait for list to populate
-    await expect(page.locator('div').filter({ hasText: apiName }).first()).toBeVisible({ timeout: 25000 })
+    await expect(page.locator('div').filter({ hasText: apiName }).first()).toBeVisible({ timeout: 15000 })
   })
 
   test('create HTTP API and verify in list', async ({ page }) => {
@@ -160,7 +171,7 @@ test.describe('API Gateway', () => {
   })
 
   test('open create REST API modal', async ({ page }) => {
-    await page.goto('http://localhost:3000/#/services/api-gateway')
+    await page.goto('/#/services/api-gateway')
     await page.waitForLoadState('networkidle')
 
     // Click create button
@@ -180,7 +191,7 @@ test.describe('API Gateway', () => {
   })
 
   test('open create HTTP API modal', async ({ page }) => {
-    await page.goto('http://localhost:3000/#/services/api-gateway')
+    await page.goto('/#/services/api-gateway')
     await page.waitForLoadState('networkidle')
 
     // Switch to HTTP APIs tab
@@ -234,23 +245,40 @@ test.describe('API Gateway', () => {
     }
   })
 
-test('tabs switch correctly between REST and HTTP', async ({ page }) => {
-  await page.goto('http://localhost:3000/#/services/api-gateway')
-  await page.waitForLoadState('networkidle')
+  test('tabs switch correctly between REST and HTTP', async ({ page }) => {
+    await page.goto('/#/services/api-gateway')
+    await page.waitForLoadState('networkidle')
 
-  // Default is REST APIs - verify create button says "REST API"
-  await expect(page.getByRole('button', { name: 'Create REST API' }).first()).toBeVisible()
+    // Default is REST APIs - verify create button says "REST API"
+    await expect(page.getByRole('button', { name: 'Create REST API' }).first()).toBeVisible()
 
-  // Switch to HTTP APIs
-  await page.getByRole('tab', { name: 'HTTP APIs' }).click()
+    // Switch to HTTP APIs
+    await page.getByRole('tab', { name: 'HTTP APIs' }).click()
 
-  // Verify create button changes to "HTTP API"
-  await expect(page.getByRole('button', { name: 'Create HTTP API' }).first()).toBeVisible()
+    // Verify create button changes to "HTTP API"
+    await expect(page.getByRole('button', { name: 'Create HTTP API' }).first()).toBeVisible()
 
-  // Switch back to REST
-  await page.getByRole('tab', { name: 'REST APIs' }).click()
+    // Switch back to REST
+    await page.getByRole('tab', { name: 'REST APIs' }).click()
 
-  // Verify create button changes back
-  await expect(page.getByRole('button', { name: 'Create REST API' }).first()).toBeVisible()
-})
+    // Verify create button changes back
+    await expect(page.getByRole('button', { name: 'Create REST API' }).first()).toBeVisible()
+  })
+
+  test.describe('API Gateway - Pagination', () => {
+    test('show per-page selector on REST APIs tab', async ({ page }) => {
+      await page.goto('/#/services/api-gateway')
+      await page.waitForLoadState('networkidle')
+      await expect(page.getByText('Show:').first()).toBeVisible()
+      await expect(page.getByText('per page').first()).toBeVisible()
+    })
+
+    test('show per-page selector on HTTP APIs tab', async ({ page }) => {
+      await page.goto('/#/services/api-gateway')
+      await page.waitForLoadState('networkidle')
+      await page.getByRole('tab', { name: 'HTTP APIs' }).click()
+      await expect(page.getByText('Show:').first()).toBeVisible()
+      await expect(page.getByText('per page').first()).toBeVisible()
+    })
+  })
 })

--- a/pkg/test/e2e/services/dynamodb.spec.ts
+++ b/pkg/test/e2e/services/dynamodb.spec.ts
@@ -9,7 +9,7 @@ async function findTableOnPage(page: any, tableName: string, maxPages = 5): Prom
     }
     // Try clicking Next button if available
     const nextBtn = page.getByRole('button', { name: 'Next' })
-    if (await nextBtn.isVisible({ timeout: 1000 }).catch(() => false)) {
+    if (await nextBtn.isEnabled({ timeout: 1000 }).catch(() => false)) {
       await nextBtn.click()
       await page.waitForTimeout(500)
     } else {

--- a/pkg/test/e2e/services/iam.spec.ts
+++ b/pkg/test/e2e/services/iam.spec.ts
@@ -1,12 +1,21 @@
 import { test, expect } from '../fixtures.js'
 
-test.setTimeout(120000)
+async function showAllItems(page: any) {
+  // Set per-page to 50 so all items visible on one page
+  const showLabel = page.getByText('Show:')
+  if (await showLabel.isVisible({ timeout: 2000 }).catch(() => false)) {
+    const perPageSelect = showLabel.locator('..').locator('select')
+    await perPageSelect.selectOption('50')
+    await page.waitForTimeout(300)
+  }
+}
 
 async function switchTab(page: any, tabName: string) {
   await page.goto('/#/services/iam')
   await page.waitForLoadState('networkidle')
   await page.getByRole('tab', { name: tabName }).click()
   await expect(page.getByRole('tab', { name: tabName })).toBeVisible()
+  await showAllItems(page)
 }
 
 async function createUser(page: any, userName: string) {
@@ -17,7 +26,8 @@ async function createUser(page: any, userName: string) {
   await expect(page.getByRole('dialog')).toBeVisible({ timeout: 15000 })
   await page.getByPlaceholder('username').fill(userName)
   await page.getByRole('dialog').getByRole('button', { name: 'Create' }).click()
-  await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 30000 })
+  await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 15000 })
+  await showAllItems(page)
 }
 
 async function createRole(page: any, roleName: string) {
@@ -31,7 +41,8 @@ async function createRole(page: any, roleName: string) {
     Statement: [{ Effect: 'Allow', Principal: { Service: 'ec2.amazonaws.com' }, Action: 'sts:AssumeRole' }]
   }))
   await page.getByRole('dialog').getByRole('button', { name: 'Create' }).click()
-  await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 30000 })
+  await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 15000 })
+  await showAllItems(page)
 }
 
 async function createGroup(page: any, groupName: string) {
@@ -41,7 +52,8 @@ async function createGroup(page: any, groupName: string) {
   await expect(page.getByRole('dialog')).toBeVisible({ timeout: 15000 })
   await page.getByPlaceholder('my-group').fill(groupName)
   await page.getByRole('dialog').getByRole('button', { name: 'Create' }).click()
-  await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 30000 })
+  await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 15000 })
+  await showAllItems(page)
 }
 
 async function createPolicy(page: any, policyName: string) {
@@ -56,14 +68,15 @@ async function createPolicy(page: any, policyName: string) {
     Statement: [{ Effect: 'Allow', Action: ['s3:GetObject'], Resource: '*' }]
   }))
   await page.getByRole('dialog').getByRole('button', { name: 'Create' }).click()
-  await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 30000 })
+  await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 15000 })
+  await showAllItems(page)
 }
 
 test.describe('IAM - Users', () => {
   test('create user and verify in list', async ({ page }) => {
     const userName = 'test-user-' + Date.now()
     await createUser(page, userName)
-    await expect(page.getByText(userName).first()).toBeVisible({ timeout: 30000 })
+    await expect(page.getByText(userName).first()).toBeVisible({ timeout: 15000 })
   })
 
   test('delete user', async ({ page }) => {
@@ -73,7 +86,7 @@ test.describe('IAM - Users', () => {
     await userRow.locator('button').first().click()
     await expect(page.getByRole('dialog')).toBeVisible({ timeout: 15000 })
     await page.getByRole('dialog').getByRole('button', { name: 'Delete' }).click()
-    await expect(page.getByText(userName).first()).not.toBeVisible({ timeout: 30000 })
+    await expect(page.getByText(userName).first()).not.toBeVisible({ timeout: 15000 })
   })
 
   test('expand user row and see access keys section', async ({ page }) => {
@@ -98,7 +111,7 @@ test.describe('IAM - Roles', () => {
   test('create role and verify in list', async ({ page }) => {
     const roleName = 'test-role-' + Date.now()
     await createRole(page, roleName)
-    await expect(page.getByText(roleName).first()).toBeVisible({ timeout: 30000 })
+    await expect(page.getByText(roleName).first()).toBeVisible({ timeout: 15000 })
   })
 
   test('delete role', async ({ page }) => {
@@ -108,7 +121,7 @@ test.describe('IAM - Roles', () => {
     await roleRow.locator('button').first().click()
     await expect(page.getByRole('dialog')).toBeVisible({ timeout: 15000 })
     await page.getByRole('dialog').getByRole('button', { name: 'Delete' }).click()
-    await expect(page.getByText(roleName).first()).not.toBeVisible({ timeout: 30000 })
+    await expect(page.getByText(roleName).first()).not.toBeVisible({ timeout: 15000 })
   })
 
   test('expand role row and see attach policy button', async ({ page }) => {
@@ -133,18 +146,18 @@ test.describe('IAM - Policies', () => {
   test('create policy and verify in list', async ({ page }) => {
     const policyName = 'test-policy-' + Date.now()
     await createPolicy(page, policyName)
-    await expect(page.getByText(policyName).first()).toBeVisible({ timeout: 30000 })
+    await expect(page.getByText(policyName).first()).toBeVisible({ timeout: 15000 })
   })
 
   test('delete policy', async ({ page }) => {
     const policyName = 'test-policy-del-' + Date.now()
     await createPolicy(page, policyName)
-    await expect(page.getByText(policyName).first()).toBeVisible({ timeout: 30000 })
+    await expect(page.getByText(policyName).first()).toBeVisible({ timeout: 15000 })
     const policyRow = page.locator('.rounded-lg').filter({ hasText: policyName }).first()
     await policyRow.locator('button').first().click()
     await expect(page.getByRole('dialog')).toBeVisible({ timeout: 15000 })
     await page.getByRole('dialog').getByRole('button', { name: 'Delete' }).click()
-    await expect(page.getByText(policyName).first()).not.toBeVisible({ timeout: 30000 })
+    await expect(page.getByText(policyName).first()).not.toBeVisible({ timeout: 15000 })
   })
 
   test('expand policy row', async ({ page }) => {
@@ -160,7 +173,7 @@ test.describe('IAM - Groups', () => {
   test('create group and verify in list', async ({ page }) => {
     const groupName = 'test-group-' + Date.now()
     await createGroup(page, groupName)
-    await expect(page.getByText(groupName).first()).toBeVisible({ timeout: 30000 })
+    await expect(page.getByText(groupName).first()).toBeVisible({ timeout: 15000 })
   })
 
   test('delete group', async ({ page }) => {
@@ -170,7 +183,7 @@ test.describe('IAM - Groups', () => {
     await groupRow.locator('button').first().click()
     await expect(page.getByRole('dialog')).toBeVisible({ timeout: 15000 })
     await page.getByRole('dialog').getByRole('button', { name: 'Delete' }).click()
-    await expect(page.getByText(groupName).first()).not.toBeVisible({ timeout: 30000 })
+    await expect(page.getByText(groupName).first()).not.toBeVisible({ timeout: 15000 })
   })
 
   test('expand group row and see add user button', async ({ page }) => {
@@ -225,5 +238,38 @@ test.describe('IAM - Navigation', () => {
     await page.goto('/#/services/iam')
     await page.waitForLoadState('networkidle')
     await expect(page.getByRole('button', { name: 'Create User' }).first()).toBeVisible({ timeout: 10000 })
+  })
+})
+
+test.describe('IAM - Pagination', () => {
+  test('show per-page selector on users tab', async ({ page }) => {
+    await page.goto('/#/services/iam')
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByText('Show:').first()).toBeVisible()
+    await expect(page.getByText('per page').first()).toBeVisible()
+  })
+
+  test('show per-page selector on roles tab', async ({ page }) => {
+    await page.goto('/#/services/iam')
+    await page.waitForLoadState('networkidle')
+    await page.getByRole('tab', { name: 'Roles' }).click()
+    await expect(page.getByText('Show:').first()).toBeVisible()
+    await expect(page.getByText('per page').first()).toBeVisible()
+  })
+
+  test('show per-page selector on policies tab', async ({ page }) => {
+    await page.goto('/#/services/iam')
+    await page.waitForLoadState('networkidle')
+    await page.getByRole('tab', { name: 'Policies' }).click()
+    await expect(page.getByText('Show:').first()).toBeVisible()
+    await expect(page.getByText('per page').first()).toBeVisible()
+  })
+
+  test('show per-page selector on groups tab', async ({ page }) => {
+    await page.goto('/#/services/iam')
+    await page.waitForLoadState('networkidle')
+    await page.getByRole('tab', { name: 'Groups' }).click()
+    await expect(page.getByText('Show:').first()).toBeVisible()
+    await expect(page.getByText('per page').first()).toBeVisible()
   })
 })

--- a/pkg/test/e2e/services/kinesis.spec.ts
+++ b/pkg/test/e2e/services/kinesis.spec.ts
@@ -9,7 +9,7 @@ async function findStreamOnPage(page: any, streamName: string, maxPages = 5): Pr
     }
     // Try clicking Next button if available
     const nextBtn = page.getByRole('button', { name: 'Next' })
-    if (await nextBtn.isVisible({ timeout: 1000 }).catch(() => false)) {
+    if (await nextBtn.isEnabled({ timeout: 1000 }).catch(() => false)) {
       await nextBtn.click()
       await page.waitForTimeout(500)
     } else {

--- a/pkg/test/e2e/services/kms.spec.ts
+++ b/pkg/test/e2e/services/kms.spec.ts
@@ -1,5 +1,22 @@
 import { test, expect } from '../fixtures.js'
 
+async function findKeyOnPage(page: any, keyDescription: string, maxPages = 5): Promise<boolean> {
+  for (let i = 0; i < maxPages; i++) {
+    const key = page.getByText(keyDescription, { exact: true })
+    if (await key.isVisible({ timeout: 2000 }).catch(() => false)) {
+      return true
+    }
+    const nextBtn = page.getByRole('button', { name: 'Next' })
+    if (await nextBtn.isEnabled({ timeout: 1000 }).catch(() => false)) {
+      await nextBtn.click()
+      await page.waitForTimeout(500)
+    } else {
+      break
+    }
+  }
+  return false
+}
+
 // Helper function to create a KMS key
 async function createKey(page: any, description: string) {
   await page.goto('/#/services/kms')
@@ -28,7 +45,7 @@ test.describe('KMS', () => {
 
     await createKey(page, keyDescription)
 
-    // Verify key appears in list (pagination-safe: new key always on page 1)
+    // Key descriptions not visible in list view, verify any key card exists
     await expect(page.locator('div.border.rounded-lg').first()).toBeVisible({ timeout: 15000 })
   })
 

--- a/pkg/test/e2e/services/s3.spec.ts
+++ b/pkg/test/e2e/services/s3.spec.ts
@@ -9,7 +9,7 @@ async function findBucketOnPage(page: any, bucketName: string, maxPages = 5): Pr
     }
     // Try clicking Next button if available
     const nextBtn = page.getByRole('button', { name: 'Next' })
-    if (await nextBtn.isVisible({ timeout: 1000 }).catch(() => false)) {
+    if (await nextBtn.isEnabled({ timeout: 1000 }).catch(() => false)) {
       await nextBtn.click()
       await page.waitForTimeout(500)
     } else {

--- a/pkg/test/e2e/services/secretsmanager.spec.ts
+++ b/pkg/test/e2e/services/secretsmanager.spec.ts
@@ -8,7 +8,7 @@ async function findSecretOnPage(page: any, secretName: string, maxPages = 5): Pr
       return true
     }
     const nextBtn = page.getByRole('button', { name: 'Next' })
-    if (await nextBtn.isVisible({ timeout: 1000 }).catch(() => false)) {
+    if (await nextBtn.isEnabled({ timeout: 1000 }).catch(() => false)) {
       await nextBtn.click()
       await page.waitForTimeout(500)
     } else {

--- a/pkg/test/e2e/services/sns.spec.ts
+++ b/pkg/test/e2e/services/sns.spec.ts
@@ -8,7 +8,7 @@ async function findTopicOnPage(page: any, topicName: string, maxPages = 5): Prom
       return true
     }
     const nextBtn = page.getByRole('button', { name: 'Next' })
-    if (await nextBtn.isVisible({ timeout: 1000 }).catch(() => false)) {
+    if (await nextBtn.isEnabled({ timeout: 1000 }).catch(() => false)) {
       await nextBtn.click()
       await page.waitForTimeout(500)
     } else {

--- a/pkg/test/e2e/services/sqs.spec.ts
+++ b/pkg/test/e2e/services/sqs.spec.ts
@@ -9,7 +9,7 @@ async function findQueueOnPage(page: any, queueName: string, maxPages = 5): Prom
     }
     // Try clicking Next button if available
     const nextBtn = page.getByRole('button', { name: 'Next' })
-    if (await nextBtn.isVisible({ timeout: 1000 }).catch(() => false)) {
+    if (await nextBtn.isEnabled({ timeout: 1000 }).catch(() => false)) {
       await nextBtn.click()
       await page.waitForTimeout(500)
     } else {

--- a/pkg/test/e2e/services/ssm.spec.ts
+++ b/pkg/test/e2e/services/ssm.spec.ts
@@ -8,7 +8,7 @@ async function findParameterOnPage(page: any, paramName: string, maxPages = 5): 
       return true
     }
     const nextBtn = page.getByRole('button', { name: 'Next' })
-    if (await nextBtn.isVisible({ timeout: 1000 }).catch(() => false)) {
+    if (await nextBtn.isEnabled({ timeout: 1000 }).catch(() => false)) {
       await nextBtn.click()
       await page.waitForTimeout(500)
     } else {

--- a/pkg/test/e2e/services/stepfunctions.spec.ts
+++ b/pkg/test/e2e/services/stepfunctions.spec.ts
@@ -1,6 +1,21 @@
 import { test, expect } from '../fixtures.js'
 
-test.setTimeout(60000)
+async function findStateMachineOnPage(page: any, machineName: string, maxPages = 5): Promise<boolean> {
+  for (let i = 0; i < maxPages; i++) {
+    const item = page.getByText(machineName, { exact: true })
+    if (await item.isVisible({ timeout: 2000 }).catch(() => false)) {
+      return true
+    }
+    const nextBtn = page.getByRole('button', { name: 'Next' })
+    if (await nextBtn.isEnabled({ timeout: 1000 }).catch(() => false)) {
+      await nextBtn.click()
+      await page.waitForTimeout(500)
+    } else {
+      break
+    }
+  }
+  return false
+}
 
 async function createStateMachine(page: any, machineName: string) {
   await page.goto('/#/services/step-functions')
@@ -12,7 +27,7 @@ async function createStateMachine(page: any, machineName: string) {
   await page.getByLabel('Role ARN').fill('arn:aws:iam::123456789012:role/test-role')
   await page.getByLabel('Definition').fill('{"StartAt": "HelloWorld", "States": {"HelloWorld": {"Type": "Pass", "End": true}}}')
   await page.getByRole('dialog').getByRole('button', { name: 'Create' }).click()
-  await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 30000 })
+  await expect(page.getByRole('dialog')).not.toBeVisible({ timeout: 15000 })
 }
 
 test.describe('Step Functions', () => {
@@ -31,7 +46,8 @@ test.describe('Step Functions', () => {
   test('create state machine and verify in list', async ({ page }) => {
     const machineName = 'test-machine-create-' + Date.now()
     await createStateMachine(page, machineName)
-    await expect(page.getByText(machineName).first()).toBeVisible({ timeout: 30000 })
+    const found = await findStateMachineOnPage(page, machineName)
+    expect(found).toBe(true)
   })
 
   test('delete state machine', async ({ page }) => {
@@ -39,19 +55,22 @@ test.describe('Step Functions', () => {
     await createStateMachine(page, machineName)
     // Wait for page to settle after creation
     await page.waitForLoadState('networkidle')
-    await expect(page.getByText(machineName).first()).toBeVisible({ timeout: 30000 })
+    const found = await findStateMachineOnPage(page, machineName)
+    expect(found).toBe(true)
     // Use more specific selector: find div with both 'border' and 'rounded-lg' classes
     const machineRow = page.locator('div.border.rounded-lg').filter({ hasText: machineName }).first()
     await machineRow.locator('[aria-label="Delete"]').click()
     await expect(page.getByRole('dialog')).toBeVisible({ timeout: 15000 })
     await page.getByRole('dialog').getByRole('button', { name: 'Delete' }).click()
-    await expect(page.getByText(machineName).first()).not.toBeVisible({ timeout: 30000 })
+    await page.waitForLoadState('networkidle')
+    await expect(page.getByText(machineName).first()).not.toBeVisible({ timeout: 15000 })
   })
 
   test('accordion expands and shows details', async ({ page }) => {
     const machineName = 'test-machine-acc-' + Date.now()
     await createStateMachine(page, machineName)
-    await expect(page.getByText(machineName).first()).toBeVisible({ timeout: 30000 })
+    const found = await findStateMachineOnPage(page, machineName)
+    expect(found).toBe(true)
     // Click the machine name text to expand accordion
     await page.getByText(machineName).first().click()
     await expect(page.getByText('ARN:').first()).toBeVisible({ timeout: 5000 })
@@ -60,7 +79,8 @@ test.describe('Step Functions', () => {
   test('back button returns to list view', async ({ page }) => {
     const machineName = 'test-machine-back-' + Date.now()
     await createStateMachine(page, machineName)
-    await expect(page.getByText(machineName).first()).toBeVisible({ timeout: 30000 })
+    const found = await findStateMachineOnPage(page, machineName)
+    expect(found).toBe(true)
     // Click View Detail to go to detail view
     await page.getByRole('button', { name: 'View Detail' }).first().click()
     await expect(page.getByRole('button', { name: /back to state machines/i }).first()).toBeVisible({ timeout: 10000 })
@@ -72,7 +92,8 @@ test.describe('Step Functions', () => {
   test('view detail shows full state machine info', async ({ page }) => {
     const machineName = 'test-machine-detail-' + Date.now()
     await createStateMachine(page, machineName)
-    await expect(page.getByText(machineName).first()).toBeVisible({ timeout: 30000 })
+    const found = await findStateMachineOnPage(page, machineName)
+    expect(found).toBe(true)
     // Click View Detail
     await page.getByRole('button', { name: 'View Detail' }).first().click()
     await expect(page.getByText(/arn/i).first()).toBeVisible({ timeout: 10000 })
@@ -82,7 +103,8 @@ test.describe('Step Functions', () => {
   test('detail view shows executions section', async ({ page }) => {
     const machineName = 'test-machine-execs-' + Date.now()
     await createStateMachine(page, machineName)
-    await expect(page.getByText(machineName).first()).toBeVisible({ timeout: 30000 })
+    const found = await findStateMachineOnPage(page, machineName)
+    expect(found).toBe(true)
     // Click View Detail to go to detail view
     await page.getByRole('button', { name: 'View Detail' }).first().click()
     await expect(page.locator('h2', { hasText: 'Executions' })).toBeVisible({ timeout: 10000 })
@@ -117,8 +139,14 @@ test.describe('Step Functions', () => {
   test('pagination shows previous/next buttons when enough state machines', async ({ page }) => {
     const machineName = 'test-machine-page-' + Date.now()
     await createStateMachine(page, machineName)
-    await expect(page.getByText(machineName).first()).toBeVisible({ timeout: 30000 })
-    // Check if pagination is visible (need > 15 items to trigger)
+    // Ensure on page 1 by setting per-page to 5
+    const showLabel = page.getByText('Show:')
+    if (await showLabel.isVisible({ timeout: 2000 }).catch(() => false)) {
+      const perPageSelect = showLabel.locator('..').locator('select')
+      await perPageSelect.selectOption('5')
+      await page.waitForTimeout(300)
+    }
+    // Check if pagination is visible (need > 5 items to trigger)
     const pagination = page.locator('text=/Page \\d+ of \\d+/').first()
     if (await pagination.isVisible({ timeout: 3000 }).catch(() => false)) {
       const prevBtn = page.getByRole('button', { name: 'Previous' })
@@ -137,7 +165,8 @@ test.describe('Step Functions', () => {
   test('view execution shows status, dates, input, output', async ({ page }) => {
     const machineName = 'test-machine-view-exec-' + Date.now()
     await createStateMachine(page, machineName)
-    await expect(page.getByText(machineName).first()).toBeVisible({ timeout: 30000 })
+    const found = await findStateMachineOnPage(page, machineName)
+    expect(found).toBe(true)
     // Click View Detail to go to detail view
     await page.getByRole('button', { name: 'View Detail' }).first().click()
     await page.waitForLoadState('networkidle')

--- a/pkg/ui/public/favicon.svg
+++ b/pkg/ui/public/favicon.svg
@@ -1,8 +1,9 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32" fill="none">
-  <rect width="32" height="32" rx="6" fill="#1e293b"/>
-  <path d="M8 12L16 8L24 12V20L16 24L8 20V12Z" stroke="#3b82f6" stroke-width="2" fill="none"/>
-  <path d="M16 8V24" stroke="#3b82f6" stroke-width="2"/>
-  <path d="M8 12L24 20" stroke="#3b82f6" stroke-width="2"/>
-  <path d="M24 12L8 20" stroke="#3b82f6" stroke-width="2"/>
-  <circle cx="16" cy="16" r="3" fill="#3b82f6"/>
+<svg width="128" height="128" viewBox="0 0 128 128" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="MyDevStack logo - constellation stack icon, light">
+  <rect x="22" y="22" width="84" height="84" rx="20" stroke="#0F172A" stroke-width="4" opacity="0.9"/>
+  <path d="M40 82L64 64M64 64L88 46M64 64L88 84M64 64L40 44" stroke="#0F172A" stroke-width="4" stroke-linecap="round"/>
+  <circle cx="64" cy="64" r="10" fill="#22C55E"/>
+  <rect x="33" y="37" width="14" height="14" rx="4" fill="#38BDF8"/>
+  <rect x="81" y="39" width="14" height="14" rx="4" fill="#38BDF8"/>
+  <rect x="81" y="77" width="14" height="14" rx="4" fill="#38BDF8"/>
+  <rect x="33" y="75" width="14" height="14" rx="4" fill="#38BDF8"/>
 </svg>

--- a/pkg/ui/src/views/services/APIGatewayHttpApis.vue
+++ b/pkg/ui/src/views/services/APIGatewayHttpApis.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import { useToast } from '@/composables/useToast'
+import { usePagination } from '@/composables/usePagination'
+import { useSettingsStore } from '@/stores/settings'
 import * as apigateway from '@/api/services/api-gateway'
 import * as lambda from '@/api/services/lambda'
 
@@ -20,6 +22,7 @@ const emit = defineEmits<{
   'edit-api': [api: any]
 }>()
 
+const settingsStore = useSettingsStore()
 const toast = useToast()
 
 const loading = ref(false)
@@ -32,6 +35,16 @@ const expandedApis = ref<Set<string>>(new Set())
 
 const lambdaFunctions = ref<any[]>([])
 const lambdaLoading = ref(false)
+
+// Pagination
+const {
+  currentPage: httpApiPage,
+  itemsPerPage: httpApisPerPage,
+  totalPages: totalHttpApiPages,
+  paginatedItems: paginatedHttpApis,
+  goToPage: goToHttpApiPage,
+  perPageOptions,
+} = usePagination(apis, { defaultPerPage: 10 })
 
 const showCreateModal = ref(false)
 const showEditModal = ref(false)
@@ -294,7 +307,7 @@ defineExpose({
 
 <template>
   <APIGatewayHttpApisList
-    :apis="apis"
+    :apis="paginatedHttpApis"
     :loading="loading"
     :expanded-apis="expandedApis"
     :stages="stages"
@@ -316,6 +329,42 @@ defineExpose({
     @edit-stage="handleEditStage"
     @delete-stage="handleDeleteStage"
   />
+
+  <!-- Pagination -->
+  <div
+    v-if="apis.length > 0"
+    class="flex flex-wrap items-center justify-between gap-4 py-4"
+  >
+    <div class="flex items-center gap-2">
+      <span class="text-sm text-light-muted dark:text-dark-muted">Show:</span>
+      <select
+        v-model="httpApisPerPage"
+        class="text-sm border rounded px-2 py-1"
+        :class="settingsStore.darkMode ? 'bg-dark-surface border-dark-border text-dark-text' : 'bg-white border-light-border text-light-text'"
+      >
+        <option v-for="opt in perPageOptions" :key="opt" :value="opt">{{ opt }}</option>
+      </select>
+      <span class="text-sm text-light-muted dark:text-dark-muted">per page</span>
+    </div>
+
+    <div v-if="totalHttpApiPages > 1" class="flex items-center gap-2">
+      <button
+        class="px-3 py-1 rounded border disabled:opacity-50"
+        :class="settingsStore.darkMode ? 'border-dark-border text-dark-text' : 'border-light-border text-light-text'"
+        :disabled="httpApiPage === 1"
+        @click="goToHttpApiPage(httpApiPage - 1)"
+      >Previous</button>
+      <span class="text-sm" :class="settingsStore.darkMode ? 'text-dark-muted' : 'text-light-muted'">
+        Page {{ httpApiPage }} of {{ totalHttpApiPages }}
+      </span>
+      <button
+        class="px-3 py-1 rounded border disabled:opacity-50"
+        :class="settingsStore.darkMode ? 'border-dark-border text-dark-text' : 'border-light-border text-light-text'"
+        :disabled="httpApiPage === totalHttpApiPages"
+        @click="goToHttpApiPage(httpApiPage + 1)"
+      >Next</button>
+    </div>
+  </div>
 
   <APIGatewayIntegrationModal
     v-if="showIntegrationModal"

--- a/pkg/ui/src/views/services/APIGatewayRestApis.vue
+++ b/pkg/ui/src/views/services/APIGatewayRestApis.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { ref, onMounted } from 'vue'
 import { useToast } from '@/composables/useToast'
+import { usePagination } from '@/composables/usePagination'
+import { useSettingsStore } from '@/stores/settings'
 import Modal from '@/components/common/Modal.vue'
 import * as apigateway from '@/api/services/api-gateway'
 import { listFunctions } from '@/api/services/lambda'
@@ -18,6 +20,7 @@ const emit = defineEmits<{
   'get-invoke-url': [api: any]
 }>()
 
+const settingsStore = useSettingsStore()
 const toast = useToast()
 
 const apis = ref<any[]>([])
@@ -44,6 +47,16 @@ const showDeleteModal = ref(false)
 const apiToDelete = ref<any>(null)
 
 const lambdaFunctions = ref<any[]>([])
+
+// Pagination
+const {
+  currentPage: restApiPage,
+  itemsPerPage: restApisPerPage,
+  totalPages: totalRestApiPages,
+  paginatedItems: paginatedRestApis,
+  goToPage: goToRestApiPage,
+  perPageOptions,
+} = usePagination(apis, { defaultPerPage: 10 })
 
 onMounted(async () => {
   await loadApis()
@@ -308,7 +321,7 @@ defineExpose({
 
 <template>
   <APIGatewayRestApisList
-    :apis="apis"
+    :apis="paginatedRestApis"
     :resources="resources"
     :loading-resources="false"
     :expanded-apis="expandedApis"
@@ -334,6 +347,42 @@ defineExpose({
     @create-stage="handleCreateStage"
     @delete-stage="confirmDeleteStage"
   />
+
+  <!-- Pagination -->
+  <div
+    v-if="apis.length > 0"
+    class="flex flex-wrap items-center justify-between gap-4 py-4"
+  >
+    <div class="flex items-center gap-2">
+      <span class="text-sm text-light-muted dark:text-dark-muted">Show:</span>
+      <select
+        v-model="restApisPerPage"
+        class="text-sm border rounded px-2 py-1"
+        :class="settingsStore.darkMode ? 'bg-dark-surface border-dark-border text-dark-text' : 'bg-white border-light-border text-light-text'"
+      >
+        <option v-for="opt in perPageOptions" :key="opt" :value="opt">{{ opt }}</option>
+      </select>
+      <span class="text-sm text-light-muted dark:text-dark-muted">per page</span>
+    </div>
+
+    <div v-if="totalRestApiPages > 1" class="flex items-center gap-2">
+      <button
+        class="px-3 py-1 rounded border disabled:opacity-50"
+        :class="settingsStore.darkMode ? 'border-dark-border text-dark-text' : 'border-light-border text-light-text'"
+        :disabled="restApiPage === 1"
+        @click="goToRestApiPage(restApiPage - 1)"
+      >Previous</button>
+      <span class="text-sm" :class="settingsStore.darkMode ? 'text-dark-muted' : 'text-light-muted'">
+        Page {{ restApiPage }} of {{ totalRestApiPages }}
+      </span>
+      <button
+        class="px-3 py-1 rounded border disabled:opacity-50"
+        :class="settingsStore.darkMode ? 'border-dark-border text-dark-text' : 'border-light-border text-light-text'"
+        :disabled="restApiPage === totalRestApiPages"
+        @click="goToRestApiPage(restApiPage + 1)"
+      >Next</button>
+    </div>
+  </div>
 
   <!-- Resource Modal -->
   <APIGatewayResourceModal

--- a/pkg/ui/src/views/services/IAM.vue
+++ b/pkg/ui/src/views/services/IAM.vue
@@ -2,6 +2,7 @@
 import { ref, computed, onMounted, watch } from 'vue'
 import { useSettingsStore } from '@/stores/settings'
 import { useContentReload } from '@/composables/useContentReload'
+import { usePagination } from '@/composables/usePagination'
 import { useToast } from '@/composables/useToast'
 import Button from '@/components/common/Button.vue'
 import LoadingSpinner from '@/components/common/LoadingSpinner.vue'
@@ -154,6 +155,43 @@ const tabs = [
   { id: 'policies', label: 'Policies', icon: KeyIcon },
   { id: 'groups', label: 'Groups', icon: UserGroupIcon },
 ]
+
+// Pagination for users
+const {
+  currentPage: userPage,
+  itemsPerPage: usersPerPage,
+  totalPages: totalUserPages,
+  paginatedItems: paginatedUsers,
+  goToPage: goToUserPage,
+  perPageOptions,
+} = usePagination(users, { defaultPerPage: 10 })
+
+// Pagination for roles
+const {
+  currentPage: rolePage,
+  itemsPerPage: rolesPerPage,
+  totalPages: totalRolePages,
+  paginatedItems: paginatedRoles,
+  goToPage: goToRolePage,
+} = usePagination(roles, { defaultPerPage: 10 })
+
+// Pagination for policies
+const {
+  currentPage: policyPage,
+  itemsPerPage: policiesPerPage,
+  totalPages: totalPolicyPages,
+  paginatedItems: paginatedPolicies,
+  goToPage: goToPolicyPage,
+} = usePagination(policies, { defaultPerPage: 10 })
+
+// Pagination for groups
+const {
+  currentPage: groupPage,
+  itemsPerPage: groupsPerPage,
+  totalPages: totalGroupPages,
+  paginatedItems: paginatedGroups,
+  goToPage: goToGroupPage,
+} = usePagination(groups, { defaultPerPage: 10 })
 
 // Computed
 const userCount = computed(() => users.value.length)
@@ -1078,7 +1116,7 @@ watch(reloadTrigger, () => {
           class="space-y-3"
         >
           <div
-            v-for="user in users"
+            v-for="user in paginatedUsers"
             :key="user.UserName"
             class="rounded-lg border border-light-border dark:border-dark-border bg-light-surface dark:bg-dark-surface"
           >
@@ -1190,6 +1228,41 @@ watch(reloadTrigger, () => {
               </div>
             </div>
           </div>
+          <!-- Pagination -->
+          <div
+            v-if="users.length > 0"
+            class="flex flex-wrap items-center justify-between gap-4 py-4"
+          >
+            <div class="flex items-center gap-2">
+              <span class="text-sm text-light-muted dark:text-dark-muted">Show:</span>
+              <select
+                v-model="usersPerPage"
+                class="text-sm border rounded px-2 py-1"
+                :class="settingsStore.darkMode ? 'bg-dark-surface border-dark-border text-dark-text' : 'bg-white border-light-border text-light-text'"
+              >
+                <option v-for="opt in perPageOptions" :key="opt" :value="opt">{{ opt }}</option>
+              </select>
+              <span class="text-sm text-light-muted dark:text-dark-muted">per page</span>
+            </div>
+
+            <div v-if="totalUserPages > 1" class="flex items-center gap-2">
+              <button
+                class="px-3 py-1 rounded border disabled:opacity-50"
+                :class="settingsStore.darkMode ? 'border-dark-border text-dark-text' : 'border-light-border text-light-text'"
+                :disabled="userPage === 1"
+                @click="goToUserPage(userPage - 1)"
+              >Previous</button>
+              <span class="text-sm" :class="settingsStore.darkMode ? 'text-dark-muted' : 'text-light-muted'">
+                Page {{ userPage }} of {{ totalUserPages }}
+              </span>
+              <button
+                class="px-3 py-1 rounded border disabled:opacity-50"
+                :class="settingsStore.darkMode ? 'border-dark-border text-dark-text' : 'border-light-border text-light-text'"
+                :disabled="userPage === totalUserPages"
+                @click="goToUserPage(userPage + 1)"
+              >Next</button>
+            </div>
+          </div>
         </div>
       </template>
 
@@ -1209,7 +1282,7 @@ watch(reloadTrigger, () => {
           class="space-y-3"
         >
           <div
-            v-for="role in roles"
+            v-for="role in paginatedRoles"
             :key="role.RoleName"
             class="rounded-lg border border-light-border dark:border-dark-border bg-light-surface dark:bg-dark-surface"
           >
@@ -1314,6 +1387,41 @@ watch(reloadTrigger, () => {
               </div>
             </div>
           </div>
+          <!-- Pagination -->
+          <div
+            v-if="roles.length > 0"
+            class="flex flex-wrap items-center justify-between gap-4 py-4"
+          >
+            <div class="flex items-center gap-2">
+              <span class="text-sm text-light-muted dark:text-dark-muted">Show:</span>
+              <select
+                v-model="rolesPerPage"
+                class="text-sm border rounded px-2 py-1"
+                :class="settingsStore.darkMode ? 'bg-dark-surface border-dark-border text-dark-text' : 'bg-white border-light-border text-light-text'"
+              >
+                <option v-for="opt in perPageOptions" :key="opt" :value="opt">{{ opt }}</option>
+              </select>
+              <span class="text-sm text-light-muted dark:text-dark-muted">per page</span>
+            </div>
+
+            <div v-if="totalRolePages > 1" class="flex items-center gap-2">
+              <button
+                class="px-3 py-1 rounded border disabled:opacity-50"
+                :class="settingsStore.darkMode ? 'border-dark-border text-dark-text' : 'border-light-border text-light-text'"
+                :disabled="rolePage === 1"
+                @click="goToRolePage(rolePage - 1)"
+              >Previous</button>
+              <span class="text-sm" :class="settingsStore.darkMode ? 'text-dark-muted' : 'text-light-muted'">
+                Page {{ rolePage }} of {{ totalRolePages }}
+              </span>
+              <button
+                class="px-3 py-1 rounded border disabled:opacity-50"
+                :class="settingsStore.darkMode ? 'border-dark-border text-dark-text' : 'border-light-border text-light-text'"
+                :disabled="rolePage === totalRolePages"
+                @click="goToRolePage(rolePage + 1)"
+              >Next</button>
+            </div>
+          </div>
         </div>
       </template>
 
@@ -1331,7 +1439,7 @@ watch(reloadTrigger, () => {
           class="space-y-3"
         >
           <div
-            v-for="policy in policies"
+            v-for="policy in paginatedPolicies"
             :key="policy.Arn"
             class="rounded-lg border border-light-border dark:border-dark-border bg-light-surface dark:bg-dark-surface"
           >
@@ -1424,6 +1532,41 @@ watch(reloadTrigger, () => {
               </div>
             </div>
           </div>
+          <!-- Pagination -->
+          <div
+            v-if="policies.length > 0"
+            class="flex flex-wrap items-center justify-between gap-4 py-4"
+          >
+            <div class="flex items-center gap-2">
+              <span class="text-sm text-light-muted dark:text-dark-muted">Show:</span>
+              <select
+                v-model="policiesPerPage"
+                class="text-sm border rounded px-2 py-1"
+                :class="settingsStore.darkMode ? 'bg-dark-surface border-dark-border text-dark-text' : 'bg-white border-light-border text-light-text'"
+              >
+                <option v-for="opt in perPageOptions" :key="opt" :value="opt">{{ opt }}</option>
+              </select>
+              <span class="text-sm text-light-muted dark:text-dark-muted">per page</span>
+            </div>
+
+            <div v-if="totalPolicyPages > 1" class="flex items-center gap-2">
+              <button
+                class="px-3 py-1 rounded border disabled:opacity-50"
+                :class="settingsStore.darkMode ? 'border-dark-border text-dark-text' : 'border-light-border text-light-text'"
+                :disabled="policyPage === 1"
+                @click="goToPolicyPage(policyPage - 1)"
+              >Previous</button>
+              <span class="text-sm" :class="settingsStore.darkMode ? 'text-dark-muted' : 'text-light-muted'">
+                Page {{ policyPage }} of {{ totalPolicyPages }}
+              </span>
+              <button
+                class="px-3 py-1 rounded border disabled:opacity-50"
+                :class="settingsStore.darkMode ? 'border-dark-border text-dark-text' : 'border-light-border text-light-text'"
+                :disabled="policyPage === totalPolicyPages"
+                @click="goToPolicyPage(policyPage + 1)"
+              >Next</button>
+            </div>
+          </div>
         </div>
       </template>
 
@@ -1443,7 +1586,7 @@ watch(reloadTrigger, () => {
           class="space-y-3"
         >
           <div
-            v-for="group in groups"
+            v-for="group in paginatedGroups"
             :key="group.GroupName"
             class="rounded-lg border border-light-border dark:border-dark-border bg-light-surface dark:bg-dark-surface"
           >
@@ -1558,6 +1701,41 @@ watch(reloadTrigger, () => {
                   </Button>
                 </div>
               </div>
+            </div>
+          </div>
+          <!-- Pagination -->
+          <div
+            v-if="groups.length > 0"
+            class="flex flex-wrap items-center justify-between gap-4 py-4"
+          >
+            <div class="flex items-center gap-2">
+              <span class="text-sm text-light-muted dark:text-dark-muted">Show:</span>
+              <select
+                v-model="groupsPerPage"
+                class="text-sm border rounded px-2 py-1"
+                :class="settingsStore.darkMode ? 'bg-dark-surface border-dark-border text-dark-text' : 'bg-white border-light-border text-light-text'"
+              >
+                <option v-for="opt in perPageOptions" :key="opt" :value="opt">{{ opt }}</option>
+              </select>
+              <span class="text-sm text-light-muted dark:text-dark-muted">per page</span>
+            </div>
+
+            <div v-if="totalGroupPages > 1" class="flex items-center gap-2">
+              <button
+                class="px-3 py-1 rounded border disabled:opacity-50"
+                :class="settingsStore.darkMode ? 'border-dark-border text-dark-text' : 'border-light-border text-light-text'"
+                :disabled="groupPage === 1"
+                @click="goToGroupPage(groupPage - 1)"
+              >Previous</button>
+              <span class="text-sm" :class="settingsStore.darkMode ? 'text-dark-muted' : 'text-light-muted'">
+                Page {{ groupPage }} of {{ totalGroupPages }}
+              </span>
+              <button
+                class="px-3 py-1 rounded border disabled:opacity-50"
+                :class="settingsStore.darkMode ? 'border-dark-border text-dark-text' : 'border-light-border text-light-text'"
+                :disabled="groupPage === totalGroupPages"
+                @click="goToGroupPage(groupPage + 1)"
+              >Next</button>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Description

Add pagination for IAM and ApiGateway, and improve test speed, reducing timeouts

## Type of Change

- [x] Frontend Only

---

## Checklist

### Frontend (Vue)
- [x] **View** — `views/services/<Service>.vue`: working UI
- [x] **Tests pass** — `cd pkg/ui && npm run test:run`

### E2E
- [x] **E2E spec** — `pkg/test/e2e/services/<service>.spec.ts`: nav, create, delete, cancel, toast, pagination
- [x] **All E2E pass** — `make test-e2e` (requires AWS emulator on :4566)

---
