### PR TITLE
FIX: MSK - OpenSearch - change scope for ministack as not yet supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ mydevstack/
 
 ## Supported AWS Services
 
+> **MiniStack note**: MSK and OpenSearch are not supported by MiniStack. The UI shows a warning banner and disables create actions when running on MiniStack.
+
 | Service | Status | Description |
 |---------|--------|-------------|
 | S3 | ✅ | Buckets, Objects, Presigned URLs |
@@ -158,6 +160,8 @@ mydevstack/
 | RDS | ✅ | Databases, Instances, Snapshots |
 | SES | ✅ | Emails, Templates, Send |
 | Step Functions | ✅ | State Machines, Executions |
+| OpenSearch | ✅ | Domains, Config (requires LocalStack or FloCi) |
+| MSK | ✅ | Clusters, Bootstrap Brokers (requires LocalStack or FloCi) |
 
 ---
 

--- a/pkg/ui/src/components/layout/Sidebar.vue
+++ b/pkg/ui/src/components/layout/Sidebar.vue
@@ -603,7 +603,10 @@ const handleServiceClick = (service: Service) => {
             d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
           />
         </svg>
-        <div class="flex-1 min-w-0">
+        <div
+          v-if="!collapsed"
+          class="flex-1 min-w-0"
+        >
           <p class="text-sm font-medium text-blue-800 dark:text-blue-200">
             A new version has been released
           </p>

--- a/pkg/ui/src/composables/useMSK.test.ts
+++ b/pkg/ui/src/composables/useMSK.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
+import { useSettingsStore } from '@/stores/settings'
 import { useMSK } from './useMSK'
 
 // Mock the MSK API module
@@ -105,6 +106,20 @@ describe('useMSK', () => {
 
       await loadClusters()
 
+      expect(clusters.value).toEqual([])
+      expect(isAvailable.value).toBe(false)
+      expect(isLoading.value).toBe(false)
+    })
+
+    it('skips API call and sets unavailable when emulator is ministack', async () => {
+      const settingsStore = useSettingsStore()
+      settingsStore.emulator = 'MINISTACK'
+
+      const { loadClusters, clusters, isAvailable, isLoading } = useMSK()
+
+      await loadClusters()
+
+      expect(mskApi.listClustersV2).not.toHaveBeenCalled()
       expect(clusters.value).toEqual([])
       expect(isAvailable.value).toBe(false)
       expect(isLoading.value).toBe(false)

--- a/pkg/ui/src/composables/useMSK.ts
+++ b/pkg/ui/src/composables/useMSK.ts
@@ -1,5 +1,6 @@
 import { ref, computed } from 'vue'
 import { useToast } from '@/composables/useToast'
+import { useSettingsStore } from '@/stores/settings'
 import * as mskApi from '@/api/services/msk'
 
 // Types
@@ -52,6 +53,7 @@ export interface MSKNodeInfo {
 
 export function useMSK() {
   const toast = useToast()
+  const settingsStore = useSettingsStore()
 
   // State
   const clusters = ref<MSKClusterSummary[]>([])
@@ -113,6 +115,13 @@ export function useMSK() {
   // API functions
   async function loadClusters() {
     isLoading.value = true
+    // Check if emulator is ministack — skip API calls
+    if (settingsStore.emulator && settingsStore.emulator.toLowerCase() === 'ministack') {
+      isAvailable.value = false
+      clusters.value = []
+      isLoading.value = false
+      return
+    }
     try {
       const result = await mskApi.listClustersV2()
       clusters.value = result.ClusterInfoList || []

--- a/pkg/ui/src/composables/useOpenSearch.test.ts
+++ b/pkg/ui/src/composables/useOpenSearch.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { setActivePinia, createPinia } from 'pinia'
 import { useOpenSearch } from './useOpenSearch'
+import { useSettingsStore } from '@/stores/settings'
 
 const mockDescribeDomain = vi.fn()
 const mockListTags = vi.fn()
@@ -22,6 +23,7 @@ vi.mock('@/api/services/opensearch', () => ({
 vi.mock('@/stores/settings', () => ({
   useSettingsStore: vi.fn(() => ({
     region: 'us-east-1',
+    emulator: '',
     accessKey: 'test-key',
     secretKey: 'test-secret',
   })),
@@ -36,9 +38,10 @@ describe('useOpenSearch', () => {
   })
 
   it('initializes with empty state', () => {
-    const { domains, loading, expandedDomains, showCreateModal, showDeleteConfirm } = useOpenSearch()
+    const { domains, loading, isAvailable, expandedDomains, showCreateModal, showDeleteConfirm } = useOpenSearch()
     expect(domains.value).toEqual([])
     expect(loading.value).toBe(false)
+    expect(isAvailable.value).toBe(true)
     expect(expandedDomains.value).toEqual(new Set())
     expect(showCreateModal.value).toBe(false)
     expect(showDeleteConfirm.value).toBe(false)
@@ -64,12 +67,31 @@ describe('useOpenSearch', () => {
   it('loadDomains handles error', async () => {
     vi.mocked(openSearchApi.listDomainNames).mockRejectedValue(new Error('Network error'))
 
-    const { loadDomains, loading, domains } = useOpenSearch()
+    const { loadDomains, loading, domains, isAvailable } = useOpenSearch()
 
     await loadDomains()
 
     expect(loading.value).toBe(false)
     expect(domains.value).toEqual([])
+    expect(isAvailable.value).toBe(false)
+  })
+
+  it('skips API call and sets unavailable when emulator is ministack', async () => {
+    vi.mocked(useSettingsStore).mockReturnValueOnce({
+      region: 'us-east-1',
+      emulator: 'MINISTACK',
+      accessKey: 'test-key',
+      secretKey: 'test-secret',
+    })
+
+    const { loadDomains, domains, loading, isAvailable } = useOpenSearch()
+
+    await loadDomains()
+
+    expect(openSearchApi.listDomainNames).not.toHaveBeenCalled()
+    expect(domains.value).toEqual([])
+    expect(isAvailable.value).toBe(false)
+    expect(loading.value).toBe(false)
   })
 
   it('createDomain validates required name', async () => {

--- a/pkg/ui/src/composables/useOpenSearch.ts
+++ b/pkg/ui/src/composables/useOpenSearch.ts
@@ -10,6 +10,7 @@ export function useOpenSearch() {
 
   const domains = ref<DomainInfo[]>([])
   const loading = ref(false)
+  const isAvailable = ref(true)
   const expandedDomains = ref<Set<string>>(new Set())
 
   const showCreateModal = ref(false)
@@ -44,13 +45,20 @@ export function useOpenSearch() {
 
   async function loadDomains() {
     loading.value = true
+    // Check if emulator is ministack — skip API calls
+    if (settingsStore.emulator && settingsStore.emulator.toLowerCase() === 'ministack') {
+      isAvailable.value = false
+      domains.value = []
+      loading.value = false
+      return
+    }
     try {
       const result = await openSearchApi.listDomainNames()
       domains.value = result
+      isAvailable.value = true
     } catch (error: any) {
-      console.error('Failed to load domains:', error)
-      toast.error(`Failed to load domains: ${error}`)
       domains.value = []
+      isAvailable.value = false
     } finally {
       loading.value = false
     }
@@ -174,11 +182,16 @@ export function useOpenSearch() {
 
   async function loadCompatibleVersions() {
     loadingCompatibleVersions.value = true
+    // Check if emulator is ministack — skip API calls
+    if (settingsStore.emulator && settingsStore.emulator.toLowerCase() === 'ministack') {
+      compatibleVersions.value = []
+      loadingCompatibleVersions.value = false
+      return
+    }
     try {
       const result = await openSearchApi.getCompatibleVersions()
       compatibleVersions.value = result.CompatibleVersions || []
-    } catch (error: any) {
-      console.error('Failed to load compatible versions:', error)
+    } catch {
       compatibleVersions.value = []
     } finally {
       loadingCompatibleVersions.value = false
@@ -399,6 +412,7 @@ client.DeleteDomain(context.Background(), &opensearch.DeleteDomainInput{
   return {
     domains,
     loading,
+    isAvailable,
     expandedDomains,
     showCreateModal,
     creating,

--- a/pkg/ui/src/composables/useServiceRegistry.ts
+++ b/pkg/ui/src/composables/useServiceRegistry.ts
@@ -15,6 +15,7 @@ import { listSecrets as fetchSecrets } from '@/api/services/secrets-manager'
 import { describeReplicationGroups as fetchElastiCacheGroups } from '@/api/services/elasticache'
 import { listDomainNames as fetchOpenSearchDomains } from '@/api/services/opensearch'
 import { describeParameters as fetchSSMParameters } from '@/api/services/ssm'
+import { useSettingsStore } from '@/stores/settings'
 import type { ServiceCategory } from '@/types/services'
 import { SERVICE_COLORS, type ServiceStats, type ServiceStatus, determineStatus } from '@/types/serviceRegistry'
 
@@ -331,6 +332,19 @@ export function useServiceRegistry() {
         continue
       }
 
+      // Skip API calls for MSK and OpenSearch on ministack
+      const settingsStore = useSettingsStore()
+      if (settingsStore.emulator && settingsStore.emulator.toLowerCase() === 'ministack' &&
+          (service.id === 'msk' || service.id === 'opensearch')) {
+        stats.value.set(service.id, {
+          serviceId: service.id,
+          count: 0,
+          status: 'unknown',
+          loading: false,
+        })
+        continue
+      }
+
       try {
         const count = await service.statsFetcher()
         stats.value.set(service.id, {
@@ -359,6 +373,15 @@ export function useServiceRegistry() {
 
     if (!service.enabled) {
       return { serviceId, count: 0, status: 'unknown', loading: false }
+    }
+
+    // Skip API calls for MSK and OpenSearch on ministack
+    const settingsStore = useSettingsStore()
+    if (settingsStore.emulator && settingsStore.emulator.toLowerCase() === 'ministack' &&
+        (service.id === 'msk' || service.id === 'opensearch')) {
+      const result = { serviceId, count: 0, status: 'unknown' as ServiceStatus, loading: false }
+      stats.value.set(serviceId, result)
+      return result
     }
 
     try {

--- a/pkg/ui/src/views/services/MSK.vue
+++ b/pkg/ui/src/views/services/MSK.vue
@@ -91,6 +91,7 @@ watch(reloadTrigger, () => {
           </Button>
           <Button
             size="sm"
+            :disabled="!isAvailable"
             @click="showCreateModal = true"
           >
             <PlusIcon class="h-4 w-4 mr-1" />

--- a/pkg/ui/src/views/services/OpenSearch.vue
+++ b/pkg/ui/src/views/services/OpenSearch.vue
@@ -25,6 +25,7 @@ import {
 const {
   domains,
   loading,
+  isAvailable,
   expandedDomains,
   showCreateModal,
   showDeleteConfirm,
@@ -126,6 +127,7 @@ watch(reloadTrigger, () => {
           </Button>
           <Button
             size="sm"
+            :disabled="!isAvailable"
             @click="showCreateModal = true"
           >
             <PlusIcon class="h-4 w-4 mr-1" />
@@ -137,13 +139,43 @@ watch(reloadTrigger, () => {
 
     <!-- Content -->
     <div class="flex-1 overflow-y-auto p-4">
+      <!-- Unavailable message -->
+      <div
+        v-if="!isAvailable && !loading"
+        class="mb-6 p-4 rounded-lg border border-yellow-300 dark:border-yellow-700 bg-yellow-50 dark:bg-yellow-900/20"
+      >
+        <div class="flex items-center gap-3">
+          <svg
+            class="h-5 w-5 text-yellow-600 dark:text-yellow-400 flex-shrink-0"
+            fill="none"
+            viewBox="0 0 24 24"
+            stroke="currentColor"
+          >
+            <path
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="2"
+              d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-2.5L13.732 4c-.77-.833-1.964-.833-2.732 0L4.082 16.5c-.77.833.192 2.5 1.732 2.5z"
+            />
+          </svg>
+          <div>
+            <p class="text-sm font-medium text-yellow-800 dark:text-yellow-200">
+              OpenSearch is not available in this environment
+            </p>
+            <p class="text-sm text-yellow-700 dark:text-yellow-300 mt-0.5">
+              The OpenSearch API is not supported by the current emulator. Some features may not work until a compatible backend is available.
+            </p>
+          </div>
+        </div>
+      </div>
+
       <!-- Empty State -->
       <EmptyState
         v-if="!loading && domains.length === 0"
         icon="server"
         title="No Domains"
         description="Create a new OpenSearch domain to get started."
-        action-label="Create Domain"
+        :action-label="isAvailable ? 'Create Domain' : undefined"
         @action="showCreateModal = true"
       />
 


### PR DESCRIPTION
## Description

<!-- 1-2 lines what this PR does -->

## Type of Change

- [x] Bug Fix / Refactor

---

## Checklist
### Frontend (Vue)
- [x] **Composable + Tests** — `composables/use<Service>.ts`: state + all operations
- [x] **Components** — `components/<service>/`: modals, code examples, barrel, storybooks, integration tests
- [x] **View** — `views/services/<Service>.vue`: working UI

### E2E
- [X] **All E2E pass** — `make test-e2e` (requires AWS emulator on :4566)

---

## Notes

<!-- Any additional notes for reviewers -->
